### PR TITLE
feat: add HTTP Basic Authentication support for private iCalendar/CalDAV feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,16 @@ Configure your calendar feeds and preferences using the in-app **Settings Menu (
     "url": "https://nextcloud.example.com/remote.php/dav/public-calendars/xxxxxxxx?export",
     "color": "#0082c9",
     "enabled": true
-  }
+  },
+   {
+      "name": "Radicale / Private CalDAV",
+      "url": "https://example.com/username/calendar-id",
+      "color": "#ff5555",
+      "username": "your_username",
+      "password": "your_password",
+      "enabled": true
+   }
+
 ]
 ```
 

--- a/fetch-events.py
+++ b/fetch-events.py
@@ -14,6 +14,7 @@ import calendar
 import urllib.request
 import urllib.parse
 import urllib.error
+import base64
 from datetime import datetime, date, timedelta
 from concurrent.futures import ThreadPoolExecutor
 
@@ -895,6 +896,18 @@ def fetch_calendar(cal_info, window_start, window_end):
     name = cal_info.get("name", "Calendar")
     raw_url = cal_info.get("url", "").strip()
 
+    username = cal_info.get("username")
+    password = cal_info.get("password")
+
+    headers = {
+        "User-Agent": USER_AGENT
+    }
+
+    if username and password:
+        auth_str = f"{username}:{password}"
+        auth_b64 = base64.b64encode(auth_str.encode("utf-8")).decode("utf-8")
+        headers["Authorization"] = f"Basic {auth_b64}"
+
     if not raw_url:
         return {"name": name, "color": cal_info.get("color", "#4A90E2"), "events": [], "status": "no_url", "count": 0}
 
@@ -918,7 +931,7 @@ def fetch_calendar(cal_info, window_start, window_end):
             with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 content = safe_read_text(f, max_bytes=MAX_ICAL_BYTES)
         else:
-            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=12) as resp:
                 raw = safe_read_bytes(resp, max_bytes=MAX_ICAL_BYTES)
                 content = raw.decode("utf-8", errors="ignore")


### PR DESCRIPTION
### Description
This Pull Request adds support for **HTTP Basic Authentication** in the iCalendar fetcher. It allows users to sync protected or private calendar feeds (such as private **Radicale**, **Nextcloud**, or self-hosted CalDAV instances) that require a username and password.

### Problem Solved
Currently, `fetch_calendar` fails with a `401 Unauthorized` HTTP error when attempting to access a secured `.ics` endpoint, as there is no mechanism to pass user credentials. 

### Changes Introduced
- **`fetch-events.py`**: Added optional extraction of `username` and `password` fields from the calendar configuration. If both are present, an `Authorization: Basic <credentials>` header is generated and injected into the HTTP request using native `base64` and `urllib`.
- **Backward Compatibility**: It is completely optional and non-breaking. If credentials are not supplied in `calendars.json`, the script falls back to standard public requests exactly as it did before.
- **`README.md`**: Updated the configuration example block to include a generic secured CalDAV/Radicale entry for user guidance.

### How to Test
1. Add a password-protected calendar to your `~/.config/omarchy/calendars.json`:
   ```json
   {
     "name": "Private Radicale",
     "url": "https://example.com",
     "color": "#ff5555",
     "username": "your_username",
     "password": "your_password",
     "enabled": true
   }
   ```
2. Run `python3 fetch-events.py`.
3. Verify that the private calendar events are fetched successfully without throwing a `401` error.
