### PR TITLE
Next event on the bar

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -35,6 +35,24 @@ BarWidget {
   readonly property string displayText: formatted(displayDate)
   readonly property var verticalLines: displayText.split("\n")
 
+  // Next timed event within the configured horizon, shown beside the clock.
+  // The panel keeps the event cache warm (sync + file watch); this view reads
+  // its parsed eventsData and recomputes on every minute the clock ticks.
+  readonly property bool showNextEvent: setting("showNextEvent", true)
+  readonly property string nextEventHorizon: String(setting("nextEventHorizon", "today"))
+  readonly property var nextEventCalendars: setting("nextEventCalendars", [])
+  readonly property var eventsByDate: panelLoader.item ? panelLoader.item.eventsData.eventsByDate : ({})
+
+  function computeNextEventText(now) {
+    if (!showNextEvent || vertical) return ""
+    var evt = Model.nextUpcomingEvent(eventsByDate, now,
+      Model.nextEventHorizonDays(nextEventHorizon), nextEventCalendars)
+    return Model.formatBarEventLabel(evt, now)
+  }
+
+  // displayDate ticks every minute, so the countdown recomputes on its own.
+  readonly property string upcomingEventText: computeNextEventText(displayDate)
+
   function refresh() {
     displayDate = new Date()
     if (panelLoader.item && panelLoader.item.refresh) panelLoader.item.refresh()
@@ -161,7 +179,9 @@ BarWidget {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.vertical ? "" : root.displayText
+    text: root.vertical ? "" : (root.upcomingEventText === ""
+      ? root.displayText
+      : root.displayText + " \u00b7 " + root.upcomingEventText)
     labelVisible: !root.vertical
     hasVisualContent: root.vertical ? root.verticalLines.length > 0 : text !== ""
     fixedHeight: root.vertical ? root.verticalLines.length * Style.bar.iconSlot : -1

--- a/Model.js
+++ b/Model.js
@@ -316,6 +316,13 @@ function stepMonth(year, month, delta) {
   return { year: target.getFullYear(), month: target.getMonth() }
 }
 
+// Lists read out of QML-backed settings can arrive as QVariantList proxies:
+// array-like, with constructor.name "Array", yet Array.isArray() says no.
+// Treat any object carrying a numeric length as a list.
+function isList(value) {
+  return !!value && typeof value === "object" && typeof value.length === "number"
+}
+
 // The next timed event still running or yet to start, looking ahead from
 // today over `horizonDays` days (1 = today only, 0 = as far as the cache
 // goes). `calendarNames` is a strict allowlist: only events from the named
@@ -336,7 +343,7 @@ function nextUpcomingEvent(eventsByDate, now, horizonDays, calendarNames) {
   if (span > 0) {
     maxKey = keyForDate(new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate() + Math.floor(span) - 1))
   }
-  var allow = Array.isArray(calendarNames) ? calendarNames : []
+  var allow = isList(calendarNames) ? calendarNames : []
 
   var keys = Object.keys(days).sort()
   var best = null
@@ -583,6 +590,7 @@ if (typeof module !== "undefined") {
     isoWeekLiteral: isoWeekLiteral,
     parseEventsFile: parseEventsFile,
     nextUpcomingEvent: nextUpcomingEvent,
+    isList: isList,
     nextEventHorizonDays: nextEventHorizonDays,
     formatEventCountdown: formatEventCountdown,
     truncateEventTitle: truncateEventTitle,

--- a/Model.js
+++ b/Model.js
@@ -316,6 +316,98 @@ function stepMonth(year, month, delta) {
   return { year: target.getFullYear(), month: target.getMonth() }
 }
 
+// The next timed event still running or yet to start, looking ahead from
+// today over `horizonDays` days (1 = today only, 0 = as far as the cache
+// goes). `calendarNames` is a strict allowlist: only events from the named
+// calendars count, and an empty or non-array list shows nothing. All-day
+// events are skipped entirely; an event counts until its end passes, so one
+// that already started (ongoing) is returned too. A missing or unparsable
+// endTime assumes one hour.
+function nextUpcomingEvent(eventsByDate, now, horizonDays, calendarNames) {
+  var days = eventsByDate || {}
+  var nowMs = now instanceof Date ? now.getTime() : Number(now)
+  if (!isFinite(nowMs)) return null
+
+  var nowDate = new Date(nowMs)
+  var todayKey = keyForDate(nowDate)
+  var span = Number(horizonDays)
+  if (!isFinite(span)) span = 1
+  var maxKey = ""
+  if (span > 0) {
+    maxKey = keyForDate(new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate() + Math.floor(span) - 1))
+  }
+  var allow = Array.isArray(calendarNames) ? calendarNames : []
+
+  var keys = Object.keys(days).sort()
+  var best = null
+  var bestStart = Infinity
+  for (var k = 0; k < keys.length; k++) {
+    var key = keys[k]
+    if (key < todayKey) continue
+    if (maxKey !== "" && key > maxKey) continue
+    var events = days[key]
+    if (!events || !events.length) continue
+    for (var i = 0; i < events.length; i++) {
+      var evt = events[i]
+      if (!evt || evt.allDay || !evt.startIso) continue
+      if (allow.indexOf(evt.calendar) === -1) continue
+      var startMs = new Date(evt.startIso).getTime()
+      if (isNaN(startMs) || startMs >= bestStart) continue
+      var endMs = NaN
+      if (evt.endTime) {
+        endMs = new Date(key + "T" + evt.endTime + ":00").getTime()
+      }
+      if (isNaN(endMs) || endMs <= startMs) endMs = startMs + 3600000
+      if (endMs <= nowMs) continue
+      best = evt
+      bestStart = startMs
+    }
+  }
+  return best
+}
+
+// Countdown notation for the bar label: minutes under half an hour, the
+// half-hour grid through two hours, the whole-hour grid beyond it. Both grids
+// round half up, so 45m reads 1h, 75m reads 1.5h, and 2:20 / 3:45 read 2h / 4h.
+function formatEventCountdown(startMs, nowMs) {
+  var diffMin = Math.round((Number(startMs) - Number(nowMs)) / 60000)
+  if (diffMin < 1) return "now"
+  if (diffMin < 30) return "in " + diffMin + "m"
+  if (diffMin <= 120) return "in " + (Math.round(diffMin / 30) * 30 / 60) + "h"
+  return "in " + Math.round(diffMin / 60) + "h"
+}
+
+function truncateEventTitle(title, maxChars) {
+  var text = String(title === undefined || title === null ? "" : title).replace(/\s+/g, " ").trim()
+  var limit = Number(maxChars) > 0 ? Number(maxChars) : 22
+  if (text.length <= limit) return text
+  return text.substring(0, limit - 1).trim() + "\u2026"
+}
+
+// Bar horizon setting to day span. Exactly the values the settings pills
+// write; anything else (or unset) falls back to today.
+function nextEventHorizonDays(value) {
+  switch (String(value === undefined || value === null ? "" : value).toLowerCase()) {
+    case "today": return 1
+    case "tomorrow": return 2
+    case "week": return 7
+    case "month": return 30
+    case "forever": return 0
+    default: return 1
+  }
+}
+
+function formatBarEventLabel(event, now) {
+  if (!event || !event.startIso) return ""
+  var nowMs = now instanceof Date ? now.getTime() : Number(now)
+  if (!isFinite(nowMs)) return ""
+  var startMs = new Date(event.startIso).getTime()
+  if (isNaN(startMs)) return ""
+  var title = truncateEventTitle(event.title)
+  if (!title) return ""
+  return title + " \u00b7 " + formatEventCountdown(startMs, nowMs)
+}
+
 function parseEventsFile(text) {
   if (!text || typeof text !== "string") {
     return { eventsByDate: {}, calendars: [], lastSyncedFormatted: "", totalEvents: 0, configuredCount: 0 }
@@ -490,6 +582,11 @@ if (typeof module !== "undefined") {
     formatEventTime: formatEventTime,
     isoWeekLiteral: isoWeekLiteral,
     parseEventsFile: parseEventsFile,
+    nextUpcomingEvent: nextUpcomingEvent,
+    nextEventHorizonDays: nextEventHorizonDays,
+    formatEventCountdown: formatEventCountdown,
+    truncateEventTitle: truncateEventTitle,
+    formatBarEventLabel: formatBarEventLabel,
     formatSelectedDateLabel: formatSelectedDateLabel,
     CALENDAR_COLORS: CALENDAR_COLORS,
     cycleCalendarColor: cycleCalendarColor,

--- a/Model.js
+++ b/Model.js
@@ -373,15 +373,20 @@ function nextUpcomingEvent(eventsByDate, now, horizonDays, calendarNames) {
   return best
 }
 
-// Countdown notation for the bar label: minutes under half an hour, the
-// half-hour grid through two hours, the whole-hour grid beyond it. Both grids
-// round half up, so 45m reads 1h, 75m reads 1.5h, and 2:20 / 3:45 read 2h / 4h.
+// Countdown notation for the bar label: 
+// - minutes under 45 minutes, 
+// - the half-hour grid through two hours
+// - the whole-hour grid through a day
+// - then full days beyond it. 
+// Each grid rounds half up, so 45m reads 1h and 2:20 / 3:45 read 2h / 4h; 
+// a day remainder of 12h or more tips to the next day (1d18h reads 2d, 6d8h reads 6d).
 function formatEventCountdown(startMs, nowMs) {
   var diffMin = Math.round((Number(startMs) - Number(nowMs)) / 60000)
   if (diffMin < 1) return "now"
-  if (diffMin < 30) return "in " + diffMin + "m"
+  if (diffMin < 45) return "in " + diffMin + "m"
   if (diffMin <= 120) return "in " + (Math.round(diffMin / 30) * 30 / 60) + "h"
-  return "in " + Math.round(diffMin / 60) + "h"
+  if (diffMin < 1410) return "in " + Math.round(diffMin / 60) + "h"
+  return "in " + Math.round(diffMin / 1440) + "d"
 }
 
 function truncateEventTitle(title, maxChars) {

--- a/Panel.qml
+++ b/Panel.qml
@@ -492,12 +492,12 @@ Panel {
   // calendars show; a missing or empty list shows nothing on the bar.
   function barCalendarShown(name) {
     var list = root.setting("nextEventCalendars", [])
-    return Array.isArray(list) && list.indexOf(name) !== -1
+    return Model.isList(list) && list.indexOf(name) !== -1
   }
 
   function toggleBarCalendar(name) {
     var stored = root.setting("nextEventCalendars", [])
-    var checked = Array.isArray(stored) ? stored.slice() : []
+    var checked = Model.isList(stored) ? stored.slice() : []
     var index = checked.indexOf(name)
     if (index === -1) checked.push(name)
     else checked.splice(index, 1)
@@ -602,6 +602,14 @@ Panel {
     watchChanges: true
     printErrors: false
     onFileChanged: root.syncCalendars(true)
+  }
+
+  // Nothing else reads the event cache until the panel is opened or the
+  // sync timer fires, so after a shell restart the bar's next-event label
+  // stayed empty. Load the cache immediately and kick a background refresh.
+  Component.onCompleted: {
+    eventsFile.reload()
+    root.syncCalendars(false)
   }
 
   Process {

--- a/Panel.qml
+++ b/Panel.qml
@@ -43,6 +43,8 @@ Panel {
   readonly property var notifyMinutesBefore: root.setting("notifyMinutesBefore", "staged")
   readonly property int syncIntervalMinutes: root.setting("syncIntervalMinutes", 15)
   readonly property bool enableMeetingLinks: root.setting("enableMeetingLinks", true)
+  readonly property bool showNextEvent: root.setting("showNextEvent", true)
+  readonly property string nextEventHorizon: String(root.setting("nextEventHorizon", "today"))
   readonly property int clockHourCycle: Model.normalizedHourCycle(root.setting(
     "clockHourCycle",
     Model.hourCycleForClockFormat(root.setting("format", "dddd HH:mm"), 24)
@@ -484,6 +486,23 @@ Panel {
     if (root.hostWidget && "settings" in root.hostWidget) root.hostWidget.settings = entry
     if (root.bar && root.bar.shell && typeof root.bar.shell.updateEntryInline === "function")
       root.bar.shell.updateEntryInline(root.moduleName, entry)
+  }
+
+  // Bar calendar allowlist: always an array, strictly applied. Only listed
+  // calendars show; a missing or empty list shows nothing on the bar.
+  function barCalendarShown(name) {
+    var list = root.setting("nextEventCalendars", [])
+    return Array.isArray(list) && list.indexOf(name) !== -1
+  }
+
+  function toggleBarCalendar(name) {
+    var stored = root.setting("nextEventCalendars", [])
+    var checked = Array.isArray(stored) ? stored.slice() : []
+    var index = checked.indexOf(name)
+    if (index === -1) checked.push(name)
+    else checked.splice(index, 1)
+    checked.sort()
+    root.persistSettings({ nextEventCalendars: checked })
   }
 
   function setClockHourCycle(hourCycle) {
@@ -3179,9 +3198,197 @@ Panel {
                 }
               }
             }
+
+            // 6. Next Event On Bar Card
+            Rectangle {
+              width: parent.width
+              height: root.showNextEvent
+                ? Style.space(62) + Style.space(30) + (root.activeCalendars.length > 0
+                  ? Style.space(26) + Style.space(22) * root.activeCalendars.length
+                  : 0)
+                : Style.space(60)
+              radius: Style.cornerRadius
+              color: Style.hoverFillFor(root.contentForeground, Color.accent)
+              border.width: Style.spacing.hairline
+              border.color: Style.normalBorderFor(root.contentForeground, Color.accent)
+              clip: true
+
+              Column {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Style.space(12)
+                spacing: Style.space(8)
+
+                Item {
+                  width: parent.width
+                  height: Style.space(36)
+
+                  Column {
+                    anchors.left: parent.left
+                    anchors.right: nextEventToggleSwitch.left
+                    anchors.rightMargin: Style.space(8)
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: Style.space(2)
+
+                    Text {
+                      textFormat: Text.PlainText
+                      text: "Next Event On Bar"
+                      color: root.contentForeground
+                      font.family: root.contentFontFamily
+                      font.pixelSize: Style.font.bodySmall
+                      font.bold: true
+                    }
+
+                    Text {
+                      textFormat: Text.PlainText
+                      text: "Show the next or ongoing event next to the clock"
+                      color: Qt.darker(root.contentForeground, 1.8)
+                      font.family: root.contentFontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+                  }
+
+                  ToggleSwitch {
+                    id: nextEventToggleSwitch
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    checked: root.showNextEvent
+                    foreground: root.contentForeground
+                    accent: Color.accent
+                    onToggled: root.persistSettings({ showNextEvent: !root.showNextEvent })
+                  }
+                }
+
+                // Look-ahead horizon, same pill shape as the sync interval.
+                Row {
+                  visible: root.showNextEvent
+                  spacing: Style.space(6)
+
+                  Text {
+                    textFormat: Text.PlainText
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Look ahead:"
+                    color: Qt.darker(root.contentForeground, 1.8)
+                    font.family: root.contentFontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+
+                  Repeater {
+                    model: [
+                      { label: "Today", value: "today" },
+                      { label: "Today+Tomorrow", value: "tomorrow" },
+                      { label: "Week", value: "week" },
+                      { label: "Month", value: "month" },
+                      { label: "Forever", value: "forever" }
+                    ]
+
+                    Rectangle {
+                      id: horizonPill
+                      required property var modelData
+                      readonly property bool isSelected: root.nextEventHorizon === modelData.value
+                      width: horizonPillText.implicitWidth + Style.space(16)
+                      height: Style.space(24)
+                      radius: Style.cornerRadius > 0 ? height / 2 : 0
+                      color: isSelected ? Color.accent : "transparent"
+                      border.width: 1
+                      border.color: isSelected ? Color.accent : Qt.darker(root.contentForeground, 1.8)
+
+                      Text {
+                        textFormat: Text.PlainText
+                        id: horizonPillText
+                        anchors.centerIn: parent
+                        text: horizonPill.modelData.label
+                        color: isSelected ? Color.background : root.contentForeground
+                        font.family: root.contentFontFamily
+                        font.pixelSize: Style.font.caption
+                        font.bold: isSelected
+                      }
+
+                      MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.persistSettings({ nextEventHorizon: horizonPill.modelData.value })
+                      }
+                    }
+                  }
+                }
+
+                // Per-calendar tickboxes, the bar's strict allowlist.
+                Column {
+                  visible: root.showNextEvent && root.activeCalendars.length > 0
+                  width: parent.width
+                  spacing: Style.space(4)
+
+                  Repeater {
+                    model: root.activeCalendars
+
+                    Item {
+                      id: barCalRow
+                      required property var modelData
+                      width: parent.width
+                      height: Style.space(20)
+                      readonly property bool isChecked: root.barCalendarShown(modelData.name)
+
+                      Row {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: Style.space(8)
+
+                        Rectangle {
+                          anchors.verticalCenter: parent.verticalCenter
+                          width: Style.space(8)
+                          height: Style.space(8)
+                          radius: Style.space(4)
+                          color: String(barCalRow.modelData.color || "#888888")
+                        }
+
+                        Text {
+                          textFormat: Text.PlainText
+                          anchors.verticalCenter: parent.verticalCenter
+                          text: barCalRow.modelData.name
+                          color: root.contentForeground
+                          font.family: root.contentFontFamily
+                          font.pixelSize: Style.font.caption
+                        }
+                      }
+
+                      Rectangle {
+                        id: barCalBox
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Style.space(16)
+                        height: Style.space(16)
+                        radius: 4
+                        color: barCalRow.isChecked ? Color.accent : "transparent"
+                        border.width: 1
+                        border.color: barCalRow.isChecked ? Color.accent : Qt.darker(root.contentForeground, 1.6)
+                        Behavior on color { ColorAnimation { duration: 120 } }
+
+                        Text {
+                          textFormat: Text.PlainText
+                          anchors.centerIn: parent
+                          visible: barCalRow.isChecked
+                          text: "\u2713"
+                          color: Color.background
+                          font.family: root.contentFontFamily
+                          font.pixelSize: Style.font.caption
+                          font.bold: true
+                        }
+                      }
+
+                      MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.toggleBarCalendar(barCalRow.modelData.name)
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
-
       }
     }
   }


### PR DESCRIPTION
## Description

Adds a "next upcoming event" display to the status bar clock, with configurable look-ahead horizon and a per-calendar allowlist.

## Problem Solved

- No visibility into upcoming meetings without opening the full calendar panel
- Users juggling multiple calendars get events from calendars they don't care about (or none at all)

## Changes Introduced

**Bar widget (`BarWidget.qml`)**
- Shows the next timed event (or an ongoing one) beside the clock, e.g. `Tuesday 2026-09-03 18:40 · Test · in 5m`
- Reads the panel's parsed event cache via `panelLoader.item` — no duplicate file view; label recomputes every minute via the existing clock tick
- New settings: `showNextEvent`, `nextEventHorizon`, `nextEventCalendars`

**Logic (`Model.js`)**
- `nextUpcomingEvent()` — scans synced events from today up to the configured horizon; strict calendar allowlist; skips all-day events; includes ongoing events (a missing/unparsable `endTime` assumes one hour)
- `formatEventCountdown()` — compact notation: `<45m → in Nm`, `30–120m → half-hour grid (0.5h/1h/1.5h/2h)`, `>120m → rounded to full hours`, `>23h30m → rounded to full days`, ties round up; ongoing events read `· now`
- `nextEventHorizonDays()` — maps `today/tomorrow/week/month/forever` to 1/2/7/30/unlimited days
- `isList()` — duck-typed array check: arrays persisted in settings arrive from QML as QVariantList wrappers, which `Array.isArray()` rejects
- `truncateEventTitle()` (~22 chars), `formatBarEventLabel()` helpers

**Settings UI (`Panel.qml`)**
- New card **"Next Event On Bar"** (last card in preferences):
  - Enable/disable toggle
  - Look-ahead pills: `Today / Today+Tomorrow / Week / Month / Forever`
  - Per-calendar tickboxes (strict allowlist — nothing selected means nothing shown); sub-options hidden while the feature is off
- `Component.onCompleted` now reloads the event cache and kicks a background sync — previously nothing populated the cache until the panel was first opened or the sync timer fired, so the bar stayed empty after every shell restart

## How to Trigger the Functionality

- Enable: open the calendar panel → settings → **Next Event On Bar** toggle; pick a horizon and tick the calendars to show (none ticked by default — the allowlist is strict)
- Requires at least one synced calendar feed with a timed event within the chosen horizon
- Verify on the bar: an upcoming event appears as `Title · in Xm / 0.5h / …`; while it runs it reads `Title · now`, then the next event takes over
- Disable: toggle off, or uncheck all calendars

## Screenshots
<img width="761" height="958" alt="image" src="https://github.com/user-attachments/assets/0dd092ae-80f7-4978-9327-bedfa10b3848" />

