### PR TITLE
fix: honor ICS DURATION when DTEND is absent

### DIFF
--- a/fetch-events.py
+++ b/fetch-events.py
@@ -936,6 +936,10 @@ def parse_ics(content, cal_info, window_start, window_end):
         elif prop_name == "DTEND":
             _, dt = parse_datetime_value(val_part, prop_params)
             current["DTEND"] = dt
+        elif prop_name == "DURATION":
+            # RFC 5545 §3.3.6: VEVENT may use DURATION instead of DTEND
+            # (e.g. Sisu / university feeds emit DTSTART + DURATION only).
+            current["DURATION"] = val_part.strip()
         elif prop_name == "SUMMARY":
             current["SUMMARY"] = unescape_ical_text(val_part)
         elif prop_name == "LOCATION":
@@ -964,7 +968,12 @@ def parse_ics(content, cal_info, window_start, window_end):
         if not start_dt:
             continue
         all_day = raw.get("all_day", False)
-        end_dt = raw.get("DTEND", start_dt + (timedelta(days=1) if all_day else timedelta(hours=1)))
+        end_dt = raw.get("DTEND")
+        if end_dt is None and raw.get("DURATION"):
+            # RFC 5545: DTEND and DURATION MUST NOT co-occur; DTEND wins if present.
+            end_dt = start_dt + parse_iso_duration(raw["DURATION"])
+        if end_dt is None:
+            end_dt = start_dt + (timedelta(days=1) if all_day else timedelta(hours=1))
         if end_dt < start_dt:
             end_dt = start_dt
 


### PR DESCRIPTION
Some ICS providers emit VEVENTs with DTSTART + DURATION and no DTEND, per RFC 5545 3.6.1.

The parser only read DTEND and fell back to a 1-hour duration, so every such event rendered as 1 hour even when the feed said PT1H45M / PT3H45M / etc. Google Calendar renders them correctly, which made it look plugin-specific.

Change:
- capture the DURATION property in parse_ics()
- prefer DTEND when present, else end = start + parse_iso_duration(DURATION)
- keep existing 1h / 1d fallback when neither is present

Verified with (DTSTART + DURATION, no DTEND): PT1H45M and PT3H45M now expand correctly and DTEND events are unchanged. Existing tests pass: test_resilience (5), test_timezone (20), test_security (30), test_plugin_contract (2).