### PR TITLE
fix: calendar panel cannot be closed — write to bar via its setter

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -346,7 +346,9 @@ Panel {
   // Summoning by hotkey moves no pointer, so a hover the bar was still
   // holding must not keep the center indicators revealed behind the panel.
   function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
+      root.bar.setCenterHoverRevealSuppressed(value)
+    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
       root.bar.centerHoverRevealSuppressed = value
   }
 


### PR DESCRIPTION
## The bug

The calendar popup cannot be dismissed at all — not by clicking outside, not by <kbd>Esc</kbd>, not by clicking the clock again, not by `qs -p /usr/share/omarchy/shell ipc call promaa.clock close`. Because `Ui/KeyboardPanel.qml` is a full-screen `WlrLayer.Overlay` layer-shell surface, the stuck panel then swallows pointer input across the whole desktop. On my machine the only way out was a reboot.

## Cause

`Panel.qml`'s `setCenterHoverRevealSuppressed()` assigned the property directly:

```qml
function setCenterHoverRevealSuppressed(value) {
  if (root.bar && "centerHoverRevealSuppressed" in root.bar)
    root.bar.centerHoverRevealSuppressed = value
}
```

Third-party plugins are not handed the real `Bar` — they get the `Ui/PluginBarApi.qml` proxy, where that property is `readonly` and writes go through a method:

```qml
readonly property bool centerHoverRevealSuppressed: _centerHoverRevealSuppressed

function setCenterHoverRevealSuppressed(value) {
  if (_setCenterHoverRevealSuppressed) _setCenterHoverRevealSuppressed(!!value)
}
```

The `in` check passes (the property exists), so the guard doesn't help, and the assignment throws:

```
WARN scene: file:///home/…/plugins/promaa.clock/Panel.qml[350:-1]:
  TypeError: Cannot assign to read-only property "centerHoverRevealSuppressed"
```

That call is the **first statement** of `close()`:

```qml
function close() {
  setCenterHoverRevealSuppressed(false)   // throws here
  if (root.editingLife) root.cancelEditingLife()
  root.controller.hide()                  // never reached
}
```

so `controller.hide()` never runs and the panel stays open forever. `open()` reaches the same line from inside a `Qt.callLater`, so the exception lands outside the open path — which is why opening looks fine and only closing is broken.

## The fix

Prefer the setter when the host exposes one, keep the direct assignment as the fallback. This is exactly what the first-party panels do — see `plugins/panels/clock/Panel.qml:121-126` and `plugins/panels/weather/Panel.qml:65-70` in the Omarchy shell:

```qml
if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
  root.bar.setCenterHoverRevealSuppressed(value)
else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
  root.bar.centerHoverRevealSuppressed = value
```

One hunk, three lines, no behaviour change for a host that does allow the write.

## Verification

On Omarchy with quickshell, plugin v1.3.1, single monitor:

- **Before:** after `ipc call promaa.clock close`, the `omarchy-keyboard-panel` entry stays mapped in `hyprctl layers` indefinitely, and repeated `close` calls do nothing. The stock `omarchy.weather` panel opens and closes cleanly under the same steps, which isolates it to this plugin rather than to `KeyboardPanel`.
- **After:** `open`, `close` and `toggle` each settle correctly — the layer appears and disappears as expected — and the `TypeError` no longer appears in the shell log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSK6RfNheoSsLbZZ2tLB53
