### PR TITLE
fix(ui): use a Nerd Font glyph for event notifications

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -421,7 +421,12 @@ Panel {
   }
 
   function sendDesktopNotification(title, body) {
-    notifyProc.command = ["notify-send", "-a", "Omarchy Calendar", "-i", "x-office-calendar", String(title || "Omarchy Calendar"), String(body || "")]
+    // Send through omarchy-notification-send with a Nerd Font glyph rather than
+    // a themed icon name: mimetype icons like x-office-calendar are absent from
+    // most icon themes, and an unresolved name renders as a broken-image
+    // placeholder. The glyph is the same literal U+F00ED character the panel
+    // header already uses.
+    notifyProc.command = ["omarchy-notification-send", "--app-name", "Omarchy Calendar", "-g", "󰃭", "-u", "normal", String(title || "Omarchy Calendar"), String(body || "")]
     notifyProc.running = true
   }
 


### PR DESCRIPTION
## The bug

Event reminder notifications render with a broken-image placeholder where the icon should be.

`sendDesktopNotification()` passes `-i x-office-calendar` to `notify-send`. That is a *mimetype* icon name. Most icon themes ship no `x-office-calendar` entry, and an unresolved name is not silently dropped — the notification surface draws its broken-image placeholder in the icon slot. Every other Omarchy notification shows a real glyph, so the calendar's reminders stand out as visibly wrong.

## The fix

Send through `omarchy-notification-send` with `-g` and a Nerd Font glyph instead of a themed icon name:

```qml
notifyProc.command = ["omarchy-notification-send", "--app-name", "Omarchy Calendar",
                      "-g", "󰃭", "-u", "normal",
                      String(title || "Omarchy Calendar"), String(body || "")]
```

Three things worth noting:

- The glyph is **U+F00ED**, the same literal calendar character the panel header already uses (`Panel.qml`, the hero-date row). It is written literally rather than as an escape, matching the fifteen other glyphs in this file — it sits above U+FFFF, so a four-digit `\u` escape cannot encode it and would silently split into U+F00E plus a stray `D`.
- `-u normal` is explicit because `omarchy-notification-send` defaults to `low`, whereas `notify-send` defaults to `normal`. Without it, this change would quietly demote every reminder.
- `--app-name` replaces `-a`; the value is unchanged, so notification grouping and any user rules keyed on "Omarchy Calendar" keep working.

This plugin is Omarchy-specific and already shells out to `omarchy-*` helpers, so the added dependency is one the install already guarantees.

## Verification

Omarchy with quickshell, plugin at `upstream/main` (0caf526), single monitor.

Sending the old and new command forms side by side through the running notification daemon: the `-i x-office-calendar` form draws the placeholder, the `-g` form draws the calendar glyph. Reminder text, title, grouping and timeout are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCGkPCQ1SENd9dUaREMv1p
