### PR TITLE
fix: resolve symlinks before O_NOFOLLOW directory checks

### DIFF
--- a/fetch-events.py
+++ b/fetch-events.py
@@ -88,7 +88,7 @@ def safe_load_json(file_path, max_bytes=MAX_CONFIG_BYTES):
     Read JSON from one descriptor, rejecting links, non-files, foreign owners,
     and files larger than the configured limit.
     """
-    dir_name = os.path.dirname(os.path.abspath(file_path))
+    dir_name = os.path.dirname(os.path.realpath(file_path))
     file_name = os.path.basename(file_path)
     dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     file_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
@@ -127,7 +127,7 @@ def write_secure_json(path, data, mode=0o600, max_bytes=MAX_CONFIG_BYTES):
     payload = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
     if len(payload) > max_bytes:
         raise ValueError(f"JSON output exceeds safety limit of {max_bytes} bytes")
-    abs_path = os.path.abspath(path)
+    abs_path = os.path.realpath(path)
     dir_name = os.path.dirname(abs_path)
     file_name = os.path.basename(abs_path)
     os.makedirs(dir_name, mode=0o700, exist_ok=True)


### PR DESCRIPTION
## Problem
`safe_load_json()` and `write_secure_json()` use `os.path.abspath(path)` to find the config file's parent directory, then open that directory with `O_NOFOLLOW` for safety. `abspath()` does not resolve symlinks, so when `~/.config/omarchy` is itself a symlink (a common dotfiles setup), the directory handed to `os.open()` is the symlink itself — and `O_NOFOLLOW` refuses to open a symlink at all (`NotADirectoryError` on Linux).

`ensure_config_exists()` catches that as a plain `OSError` and silently returns, so `calendars.json` never gets created and the calendar panel shows no events.

## Fix
Use `os.path.realpath(path)` instead of `os.path.abspath(path)` in both functions. `realpath()` resolves symlinks before the `O_NOFOLLOW` open, so the real underlying directory opens normally — the safety check itself is unchanged, it now just gets the right path to check.

## Testing
Reproduced in isolation under `/tmp` (a directory symlinked to another directory, mirroring `~/.config/omarchy -> ~/dotfiles/.config/omarchy`), never touching a real config:
- Unfixed code: `write_secure_json()`/`safe_load_json()` both raise `NotADirectoryError` through the symlink.
- Fixed code: both succeed, and the file lands correctly in the real (non-symlink) target directory.

Fixes #4