### PR TITLE
feat: support HTTP Basic Auth for private iCalendar/CalDAV feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Configure your calendar feeds and preferences using the in-app **Settings Menu (
     "url": "https://nextcloud.example.com/remote.php/dav/public-calendars/xxxxxxxx?export",
     "color": "#0082c9",
     "enabled": true
+  },
+  {
+    "name": "Radicale / Private CalDAV",
+    "url": "https://example.com/username/calendar-id",
+    "color": "#ff5555",
+    "username": "your_username",
+    "password": "your_password",
+    "enabled": true
   }
 ]
 ```

--- a/fetch-events.py
+++ b/fetch-events.py
@@ -16,6 +16,7 @@ import calendar
 import urllib.request
 import urllib.parse
 import urllib.error
+import base64
 from datetime import datetime, date, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor
 
@@ -1197,6 +1198,13 @@ def fetch_calendar(cal_info, window_start, window_end):
     if not raw_url:
         return {"name": name, "color": cal_info.get("color", "#4A90E2"), "events": [], "status": "no_url", "count": 0}
 
+    username = cal_info.get("username")
+    password = cal_info.get("password")
+    headers = {"User-Agent": USER_AGENT}
+    if username and password:
+        credentials = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("utf-8")
+        headers["Authorization"] = f"Basic {credentials}"
+
     # Convert webcal:// or webcals:// to https://
     if raw_url.startswith("webcal://"):
         url = "https://" + raw_url[9:]
@@ -1217,7 +1225,7 @@ def fetch_calendar(cal_info, window_start, window_end):
             with open(path, "r", encoding="utf-8", errors="ignore") as f:
                 content = safe_read_text(f, max_bytes=MAX_ICAL_BYTES)
         else:
-            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            req = urllib.request.Request(url, headers=headers)
             resp_content = None
             last_error = None
             # Retry transient connection resets / throttling (common on Apple iCloud CalDAV)


### PR DESCRIPTION
## Problem
`fetch_calendar()` has no way to authenticate against a password-protected feed, so private Radicale/self-hosted CalDAV/Nextcloud instances fail with a plain 401 (#1).

## Fix
Add optional `username`/`password` fields to a calendar's `calendars.json` entry. When both are present, inject a `Basic` auth `Authorization` header built from them. Fully backward compatible — calendars without these fields behave exactly as before. This follows the same shape as the existing `jmapToken` field already used elsewhere in this same config file.

Documented the new fields with a Radicale/private-CalDAV example in the README's config block.

## Note on #2
This addresses the same issue as #2, rebased against current `main` (the file has moved on quite a bit — retry logic, etc. — since that PR was opened, so it wouldn't apply cleanly as-is). Happy to close this in favor of #2 instead if that's already further along — just flagging so there's a version that applies cleanly to current `main`.

## Testing
Verified against a local HTTP server requiring Basic Auth (not a real calendar provider): correct credentials fetch and parse events successfully; missing or wrong credentials fail with the same 401 the original report described.

Fixes #1